### PR TITLE
Disable hyprpaper splash text by default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -385,6 +385,7 @@ impl ChromashApi {
             content.push_str(&format!("\nwallpaper = ,{}\n", path_str));
         }
 
+        content.push_str("\nsplash = false\n");
         fs::write(Config::hyprpaper_config(), content)?;
         Ok(())
     }


### PR DESCRIPTION
Newer versions of hyprpaper display a splash text at the bottom of the screen. This adds splash = false to the generated hyprpaper.conf to suppress it.